### PR TITLE
Add version reporting and flash bound checking

### DIFF
--- a/cpu/common/link_sections.ld
+++ b/cpu/common/link_sections.ld
@@ -25,7 +25,8 @@
  *   __stack
  */
 ENTRY(Reset_Handler)
-
+_flash_start = ORIGIN(FLASH);
+_flash_end = ORIGIN(FLASH) + LENGTH(FLASH);
  SECTIONS
  {
    /* The startup code goes first into FLASH */

--- a/host_tools/fw_update.py
+++ b/host_tools/fw_update.py
@@ -52,6 +52,28 @@ class FwUpdater(object):
         else:
             print(msg)
 
+    def _get_version(self, port):
+        #Create our edgepoint
+        try:
+            ep = XBVCSerialEP(port)
+            ep.timeout_ms = 1000
+            ep.connect()
+            ep.start()
+
+            ver = get_version_command()
+
+            ep.flush()
+
+            res = ep.send(ver, GET_VERSION_RESPONSE_ID)
+        except Exception as e:
+            print e
+            res = None
+        finally:
+            ep.stop()
+            ep.disconnect()
+
+        return res
+
     def _send_ping(self, port):
         #Create our edgepoint
         try:
@@ -80,18 +102,26 @@ class FwUpdater(object):
         ports = [x[0] for x in list_ports.comports()]
         retport = None
         self._log("Searching for an active bootloader")
-        
+
         for p in ports:
             try:
                 rsp = self._send_ping(p)
                 if not rsp == None:
-                    self._log("Found bootloader on: {}".format(p))
+                    ver = self._get_version(p)
+                    if not ver:
+                        version = '<=0.1.2'
+                    else:
+                        version = '.'.join(
+                            [str(x) for x in
+                             (ver.major, ver.minor, ver.bugfix)])
+                    self._log("Found bootloader ver: {} on: {}".format(version, p))
                     retport = p
                     break
                 else:
                     raise Exception()
 
-            except:
+            except Exception as e:
+                print e
                 pass
 
         return retport

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 import os
 from setuptools import setup
+import re
 
 # Utility function to read the README file.
 # Used for the long_description.  It's nice, because now 1) we have a top level
@@ -8,9 +9,26 @@ from setuptools import setup
 def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
+def extract_version():
+    with open('version.h') as inf:
+        lines = inf.readlines()
+
+    ver_map = {'MAJOR': 0,
+               'MINOR': 0,
+               'BUGFIX': 0}
+    for l in lines:
+        match = re.match(r'#define VER_(MAJOR|MINOR|BUGFIX) (\d+)', l)
+        if match:
+            field, ver = match.groups()
+            ver_map[field] = ver
+
+    return '.'.join([ver_map['MAJOR'],
+                     ver_map['MINOR'],
+                     ver_map['BUGFIX']])
+
 setup(
     name = "asl_f4_loader",
-    version = "0.1.2",
+    version = extract_version(),
     author = "Jeff Ciesielski",
     author_email = "jeff@autosportlabs.com",
     description = ("A library and shell script to perform firmware updates on Cortex M4 Microcontrollers. (Currently: STM32F4)"),
@@ -20,7 +38,7 @@ setup(
     packages=['asl_f4_loader'],
     package_dir={'asl_f4_loader': 'host_tools',},
     classifiers=[
-        "Development Status :: 3 - Alpha",
+        "Development Status :: 4 - Beta",
         "Topic :: Utilities",
         "License :: OSI Approved :: GPLv2 License",
     ],
@@ -31,8 +49,9 @@ setup(
         ]
     },
     install_requires=[
-        'ihextools >= 1.0.0',
+        'ihextools >= 1.1.0',
         'pyserial >= 2.7',
         'crcmod >= 1.7',
+        'XBVC >= 0.0.1'
     ]
 )

--- a/upgrade_agent/messages.yaml
+++ b/upgrade_agent/messages.yaml
@@ -60,3 +60,15 @@ ping_command:
 ping_response:
   - _targets: {device}
   - _id: 7
+
+get_version_command:
+  - _targets: {host}
+  - _id: 8
+
+get_version_response:
+  - _targets: {device}
+  - _id: 9
+  - major: u32
+  - minor: u32
+  - bugfix: u32
+

--- a/upgrade_agent/upgrade_agent_handlers.c
+++ b/upgrade_agent/upgrade_agent_handlers.c
@@ -3,28 +3,42 @@
 #include <img_utils.h>
 #include <flash_utils.h>
 #include <upgrade_agent.h>
+#include <version.h>
 
 static struct app_info_block *last_known_info;
+extern uint32_t _flash_start;
+extern uint32_t _flash_end;
+
+static int offset_in_bootloader(uint32_t offset)
+{
+	return !!((offset < (uint32_t)&_flash_end) &&
+		  (offset >= (uint32_t)&_flash_start));
+}
 
 void xbvc_handle_flash_command(struct x_flash_command *msg)
 {
 	struct x_flash_response rsp;
 	int8_t res;
-       
+
 	rsp.error = ERR_SUCCESS;
 
-	res = flash_write_block(msg->data, msg->data_len, msg->offset);
-
-	if (res)
+	if (offset_in_bootloader(msg->offset)) {
 		rsp.error = ERR_FLASH_FAIL;
+	} else {
 
+		res = flash_write_block(msg->data, msg->data_len, msg->offset);
+
+		if (res) {
+			rsp.error = ERR_FLASH_FAIL;
+		}
+	}
 	xbvc_send(&rsp, E_MSG_FLASH_RESPONSE);
 }
 
 void xbvc_handle_verify_command(struct x_verify_command *msg)
 {
 	struct x_verify_response rsp;
-	
+
 	last_known_info = scan_for_app();
 
 	if (last_known_info == NULL)
@@ -69,3 +83,17 @@ void xbvc_handle_ping_command(struct x_ping_command *msg)
 	xbvc_send(&rsp, E_MSG_PING_RESPONSE);
 	upgrade_agent_usb_flush();
 }
+
+void xbvc_handle_get_version_command(struct x_get_version_command *msg)
+{
+	struct x_get_version_response rsp;
+
+	memset(&rsp, 0, sizeof(struct x_get_version_response));
+	rsp.major = VER_MAJOR;
+	rsp.minor = VER_MINOR;
+	rsp.bugfix = VER_BUGFIX;
+
+	xbvc_send(&rsp, E_MSG_GET_VERSION_RESPONSE);
+	upgrade_agent_usb_flush();
+}
+

--- a/version.h
+++ b/version.h
@@ -1,0 +1,8 @@
+#ifndef _VERSION_H_
+#define _VERSION_H_
+
+#define VER_MAJOR 0
+#define VER_MINOR 2
+#define VER_BUGFIX 0
+
+#endif


### PR DESCRIPTION
This prevents the bootloader from attempting to overwrite itself, and
gives the app a way to report which bootloader version is present.

Additionally, it updates all dependencies to their minimum viable versions.
